### PR TITLE
inline symbols shall be marked static.

### DIFF
--- a/delta_tot_table.c
+++ b/delta_tot_table.c
@@ -414,7 +414,7 @@ Fit to the special function J(x) that is accurate to better than 3% relative and
    (PolyGamma[1, 1/2 - i x/2] - PolyGamma[1, 1 - i x/2] -    PolyGamma[1, 1/2 + i x/2] +
    PolyGamma[1, 1 + i x/2])/(12 x Zeta[3]), which we could evaluate exactly if we wanted to.
 ***************************************************************************************************/
-inline double specialJ_fit(const double x)
+static inline double specialJ_fit(const double x)
 {
 
   double x2, x4, x8;
@@ -428,7 +428,7 @@ inline double specialJ_fit(const double x)
 }
 
 /*Asymptotic series expansion from YAH. Not good when qc * x is small, but fine otherwise.*/
-inline double II(const double x, const double qc, const int n)
+static inline double II(const double x, const double qc, const int n)
 {
     return (n*n+n*n*n*qc+n*qc*x*x - x*x)* qc*gsl_sf_bessel_j0(qc*x) + (2*n+n*n*qc+qc*x*x)*cos(qc*x);
 }
@@ -439,7 +439,7 @@ inline double II(const double x, const double qc, const int n)
  * This is an approximation to integral f_0(q) q^2 j_0(qX) dq between qc and infinity.
  * It gives the fraction of the integral that is due to neutrinos above a certain threshold.
  * Arguments: vcmnu is vcrit*mnu/LIGHT */
-inline double Jfrac_high(const double x, const double qc, const double nufrac_low)
+static inline double Jfrac_high(const double x, const double qc, const double nufrac_low)
 {
     double integ=0;
     int n;

--- a/omega_nu_single.c
+++ b/omega_nu_single.c
@@ -153,7 +153,7 @@ void rho_nu_init(_rho_nu_single * const rho_nu_tab, const double a0, const doubl
 }
 
 /*Heavily non-relativistic*/
-inline double non_rel_rho_nu(const double a, const double kT, const double amnu, const double kTamnu2)
+static inline double non_rel_rho_nu(const double a, const double kT, const double amnu, const double kTamnu2)
 {
     /*The constants are Riemann zetas: 3,5,7 respectively*/
     return amnu*(kT*kT*kT)/(a*a*a*a)*(1.5*1.202056903159594+kTamnu2*45./4.*1.0369277551433704+2835./32.*kTamnu2*kTamnu2*1.0083492773819229+80325/32.*kTamnu2*kTamnu2*kTamnu2*1.0020083928260826)*get_rho_nu_conversion();
@@ -161,7 +161,7 @@ inline double non_rel_rho_nu(const double a, const double kT, const double amnu,
 
 /*Heavily relativistic: we could be more accurate here,
  * but in practice this will only be called for massless neutrinos, so don't bother.*/
-inline double rel_rho_nu(const double a, const double kT)
+static inline double rel_rho_nu(const double a, const double kT)
 {
     return 7*pow(M_PI*kT/a,4)/120.*get_rho_nu_conversion();
 }

--- a/powerspectrum.c
+++ b/powerspectrum.c
@@ -5,7 +5,7 @@
 #include "gadget_defines.h"
 
 /*Helper function for 1D window function.*/
-inline fftw_real onedinvwindow(int kx, int n)
+static inline fftw_real onedinvwindow(int kx, int n)
 {
     /*Return \pi x /(n sin(\pi x / n)) unless x = 0, in which case return 1.*/
     return kx ? M_PI*kx/(n*sin(M_PI*kx/(fftw_real)n)) : 1.0;


### PR DESCRIPTION
This broke building MP-Gadget on gcc. 